### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/apps/sumo-aws-apps/guardduty/guardduty.template.yaml
+++ b/apps/sumo-aws-apps/guardduty/guardduty.template.yaml
@@ -234,7 +234,7 @@ Resources:
           - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
         Key: !Sub "${QSS3KeyPrefix}apps/sumo-aws-apps/guardduty/cloudwatchevents.zip"
       Handler: cloudwatchevents.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Environment:
         Variables:
           SUMO_ENDPOINT: !GetAtt SumoHTTPSource.SUMO_ENDPOINT


### PR DESCRIPTION
CloudFormation templates in quickstart-sumo-logic-log-centralization have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.