### PR TITLE
Update Target S3 bucket to retain for logs

### DIFF
--- a/apps/sumo-aws-apps/WAF/waf.template.yaml
+++ b/apps/sumo-aws-apps/WAF/waf.template.yaml
@@ -376,6 +376,7 @@ Resources:
         TopicConfigurations:
           - Event: s3:ObjectCreated:Put
             Topic: !Ref SumoSNSTopic
+    DeletionPolicy: Retain
 
   SumoHostedCollector:
     Type: Custom::Collector

--- a/apps/sumo-aws-apps/cloudtrail/cloudtrail.template.yaml
+++ b/apps/sumo-aws-apps/cloudtrail/cloudtrail.template.yaml
@@ -445,6 +445,7 @@ Resources:
         TopicConfigurations:
           - Event: s3:ObjectCreated:Put
             Topic: !Ref SumoSNSTopic
+    DeletionPolicy: Retain
 
   SumoCloudTrailExportPolicy:
     Condition: create_target_s3_bucket

--- a/apps/sumo-aws-apps/common/resources.template.yaml
+++ b/apps/sumo-aws-apps/common/resources.template.yaml
@@ -307,6 +307,7 @@ Resources:
         TopicConfigurations:
           - Event: s3:ObjectCreated:Put
             Topic: !Ref SumoSNSTopic
+    DeletionPolicy: Retain
 
   SumoCloudTrailExportPolicy:
     Condition: create_cloudtrail

--- a/apps/sumo-aws-apps/config/config.template.yaml
+++ b/apps/sumo-aws-apps/config/config.template.yaml
@@ -303,6 +303,7 @@ Resources:
     Condition: create_bukcet
     Properties:
       BucketName: !Ref BucketName
+    DeletionPolicy: Retain
 
   SumoSNSTopic:
     Type: "AWS::SNS::Topic"

--- a/apps/sumo-aws-apps/s3-audit/s3audit.template.yaml
+++ b/apps/sumo-aws-apps/s3-audit/s3audit.template.yaml
@@ -341,6 +341,7 @@ Resources:
         TopicConfigurations:
           - Event: s3:ObjectCreated:Put
             Topic: !Ref SumoSNSTopic
+    DeletionPolicy: Retain
 
   SumoHostedCollector:
     Type: Custom::Collector

--- a/apps/sumo-aws-apps/security-hub/securityhub.template.yaml
+++ b/apps/sumo-aws-apps/security-hub/securityhub.template.yaml
@@ -358,6 +358,7 @@ Resources:
         TopicConfigurations:
           - Event: s3:ObjectCreated:Put
             Topic: !Ref SumoSNSTopic
+    DeletionPolicy: Retain
 
   SumoHostedCollector:
     Type: Custom::Collector

--- a/apps/sumo-aws-apps/vpc-flow-logs/vpcflowlogs.template.yaml
+++ b/apps/sumo-aws-apps/vpc-flow-logs/vpcflowlogs.template.yaml
@@ -373,6 +373,7 @@ Resources:
         TopicConfigurations:
           - Event: s3:ObjectCreated:Put
             Topic: !Ref SumoSNSTopic
+    DeletionPolicy: Retain
 
   SumoHostedCollector:
     Type: Custom::Collector


### PR DESCRIPTION
*Issue #, if available:* Set Retain S3 bucket on Stack Delete

*Description of changes:*
Updated vpcflowlogs.template.yaml, securityhub.template.yaml, s3audit.template.yaml, config.template.yaml, resources.template.yaml, cloudtrail.template.yaml, waf.template.yaml with S3 retain bucket flag.

![image](https://user-images.githubusercontent.com/47370320/120701162-21602200-c478-11eb-9e62-261447f78364.png)


By submitting this pull request, I that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
